### PR TITLE
ci: run tests on PRs

### DIFF
--- a/.github/workflows/code-checkers.yml
+++ b/.github/workflows/code-checkers.yml
@@ -1,6 +1,10 @@
 name: Static code checkers
 
-on: [push]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
 
 permissions: {}
 

--- a/.github/workflows/requirements-check.yml
+++ b/.github/workflows/requirements-check.yml
@@ -1,6 +1,10 @@
 name: Check requirements file consistency
 
-on: [push]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
 
 permissions: {}
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,6 +1,10 @@
 name: GitHub Actions Security Analysis with zizmor 🌈
 
-on: [push]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
 
 permissions: {}
 


### PR DESCRIPTION
Previously the checks were only run on branches pushed to the xcp-ng repo, or, when a branch is pushed to a forked repo, against that fork, if it has been configured to run GH actions.

This resulted in PRs for branches in a forked repo not to trigger the test actions, and we would miss any regression while the PR is open, and only get hit when the regression hits master.

Just activating those actions on pull_request in addition to push would OTOH have them run twice when we push a PR branch, so we restrict the runs on push to only happen when pushing to master.  This has a side-effect of non-PR branches not getting the checks run, which we may want to fix in the future.